### PR TITLE
Update 50.json

### DIFF
--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -85,5 +85,31 @@
     "magazines": [  ],
     "relative": { "weight": -21500, "volume": -6, "price": -1210000, "ranged_damage": -4, "dispersion": 60, "barrel_length": -1 },
     "flags": [ "RELOAD_EJECT" ]
+  },
+  {
+    "id": "as50",
+    "copy-from": "rifle_base",
+    "type": "GUN",
+    "name": "AI AS50",
+    "description": ".50 caliber anti-material rifle made by Accuracy International. with high accuracy for long range target and high fire rate, this weapon is still being used by Greek national guard.",
+    "weight": "14000 g",
+    "volume": "3500 ml",
+    "price": 1500000,
+    "to-hit": -1,
+    "bashing": 13,
+    "material": "steel",
+    "ammo": "50",
+    "range": 45,
+    "ranged_damage": -5,
+    "dispersion": 80,
+    "durability": 7,
+    "reload": 400,
+    "barrel_length": 5,
+    "default_mods": [ "bipod", "rifle_scope", "muzzle_brake" ],
+    "magazine_well": 1,
+    "magazines": [ [ "50", [ "m107a1mag" ] ] ],
+    "flags": [ "NEVER_JAMS" ]
   }
 ]
+    
+  


### PR DESCRIPTION
adding new weapons to 50 category

<!--
### How to use
Leave the headings unless they don't apply to your PR, replace commented out text (surrounded with <!–– and ––>) with text describing your PR.
NOTE: Please grant permission for repository maintainers to edit your PR.
It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.
-->

#### Summary
adds Accuracy International AS50 to the 50 category

#### Purpose of change
i've been looking around gun.json for a while and i've noticed that on 50 category there is only 1 anti-material rifle, which is M107A1.

and so i decided to contribute by adding more anti-material weapons to the 50 category, and i've been planning around 2 -3 more anti-material rifle to be added. 